### PR TITLE
fix: adjust report location for `no-anonymous-operations` rule

### DIFF
--- a/.changeset/orange-poets-shout.md
+++ b/.changeset/orange-poets-shout.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix: adjust report location for `no-anonymous-operations` rule

--- a/packages/plugin/src/rules/no-anonymous-operations.ts
+++ b/packages/plugin/src/rules/no-anonymous-operations.ts
@@ -38,16 +38,18 @@ const rule: GraphQLESLintRule = {
   create(context) {
     return {
       OperationDefinition(node) {
-        if (node && (!node.name || node.name.value === '')) {
+        const isAnonymous = (node.name?.value || '').length === 0;
+        if (isAnonymous) {
+          const { start } = node.loc;
           context.report({
             loc: {
               start: {
-                column: node.loc.start.column - 1,
-                line: node.loc.start.line,
+                column: start.column - 1,
+                line: start.line,
               },
               end: {
-                column: node.loc.start.column + node.operation.length,
-                line: node.loc.start.line,
+                column: start.column - 1 + node.operation.length,
+                line: start.line,
               },
             },
             data: {


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/7361780/139118458-e233e4ab-e4e5-4ee2-8dcb-664587f1f455.png)
after
![image](https://user-images.githubusercontent.com/7361780/139118480-5cc46cf4-f40a-474d-8505-4f58a7b361e9.png)
