### PR TITLE
fix: adjust report location for `no-operation-name-suffix` rule

### DIFF
--- a/.changeset/heavy-chicken-dream.md
+++ b/.changeset/heavy-chicken-dream.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix: adjust report location for `no-operation-name-suffix` rule

--- a/packages/plugin/src/rules/no-operation-name-suffix.ts
+++ b/packages/plugin/src/rules/no-operation-name-suffix.ts
@@ -42,12 +42,23 @@ const rule: GraphQLESLintRule = {
       'OperationDefinition, FragmentDefinition'(
         node: GraphQLESTreeNode<OperationDefinitionNode | FragmentDefinitionNode>
       ) {
-        if (node && node.name && node.name.value !== '') {
-          const invalidSuffix = (node.type === 'OperationDefinition' ? node.operation : 'fragment').toLowerCase();
+        const name = node.name?.value || '';
+        if (name.length > 0) {
+          const invalidSuffix = 'operation' in node ? node.operation : 'fragment';
 
-          if (node.name.value.toLowerCase().endsWith(invalidSuffix)) {
+          if (name.toLowerCase().endsWith(invalidSuffix)) {
+            const { start, end } = node.name.loc;
             context.report({
-              node: node.name,
+              loc: {
+                start: {
+                  column: start.column - 1 + name.length - invalidSuffix.length,
+                  line: start.line,
+                },
+                end: {
+                  column: end.column - 1 + name.length,
+                  line: end.line,
+                },
+              },
               data: {
                 invalidSuffix,
               },


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/7361780/139119923-ad1d9d7d-57f9-47b9-94b1-ca00920a7c74.png)
after
![image](https://user-images.githubusercontent.com/7361780/139119935-bff6c53e-00bd-4201-b191-a951f1b01f1f.png)
