### PR TITLE
fix: adjust report location for `require-description` rule

### DIFF
--- a/.changeset/twelve-grapes-provide.md
+++ b/.changeset/twelve-grapes-provide.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix: adjust report location for `require-description` rule

--- a/packages/plugin/src/rules/avoid-operation-name-prefix.ts
+++ b/packages/plugin/src/rules/avoid-operation-name-prefix.ts
@@ -78,15 +78,16 @@ const rule: GraphQLESLintRule<AvoidOperationNamePrefixConfig> = {
             const testName = caseSensitive ? node.name.value : node.name.value.toLowerCase();
 
             if (testName.startsWith(testKeyword)) {
+              const { start } = node.name.loc;
               context.report({
                 loc: {
                   start: {
-                    line: node.name.loc.start.line,
-                    column: node.name.loc.start.column - 1,
+                    line: start.line,
+                    column: start.column - 1,
                   },
                   end: {
-                    line: node.name.loc.start.line,
-                    column: node.name.loc.start.column + testKeyword.length - 1,
+                    line: start.line,
+                    column: start.column - 1 + testKeyword.length,
                   },
                 },
                 data: {

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -66,3 +66,5 @@ export type GraphQLESLintRule<Options = any[], WithTypeInfo extends boolean = fa
   create(context: GraphQLESLintRuleContext<Options>): GraphQLESLintRuleListener<WithTypeInfo>;
   meta: Rule.RuleMetaData & RuleDocsInfo<Options>;
 };
+
+export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/7361780/139122451-7b862940-f74b-4f4f-b371-fbbe95c61a56.png)

after
![image](https://user-images.githubusercontent.com/7361780/139122467-27a0b2d7-6325-4827-bebd-6dd7ea97b748.png)
