### PR TITLE
fix(docs): some `graphql-eslint` rules are named differently than `graphql-js` rules

### DIFF
--- a/docs/rules/fragments-on-composite-type.md
+++ b/docs/rules/fragments-on-composite-type.md
@@ -13,5 +13,5 @@ Fragments use a type condition to determine if they apply, since fragments can o
 
 ## Resources
 
-- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/FragmentsOnCompositeTypeRule.ts)
-- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/FragmentsOnCompositeTypeRule-test.ts)
+- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/FragmentsOnCompositeTypesRule.ts)
+- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/FragmentsOnCompositeTypesRule-test.ts)

--- a/docs/rules/one-field-subscriptions.md
+++ b/docs/rules/one-field-subscriptions.md
@@ -13,5 +13,5 @@ A GraphQL subscription is valid only if it contains a single root field.
 
 ## Resources
 
-- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/OneFieldSubscriptionsRule.ts)
-- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/OneFieldSubscriptionsRule-test.ts)
+- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/SingleFieldSubscriptionsRule.ts)
+- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/SingleFieldSubscriptionsRule-test.ts)

--- a/docs/rules/possible-fragment-spread.md
+++ b/docs/rules/possible-fragment-spread.md
@@ -13,5 +13,5 @@ A fragment spread is only valid if the type condition could ever possibly be tru
 
 ## Resources
 
-- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/PossibleFragmentSpreadRule.ts)
-- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/PossibleFragmentSpreadRule-test.ts)
+- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/PossibleFragmentSpreadsRule.ts)
+- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/PossibleFragmentSpreadsRule-test.ts)

--- a/docs/rules/possible-type-extension.md
+++ b/docs/rules/possible-type-extension.md
@@ -13,5 +13,5 @@ A type extension is only valid if the type is defined and has the same kind.
 
 ## Resources
 
-- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/PossibleTypeExtensionRule.ts)
-- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/PossibleTypeExtensionRule-test.ts)
+- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/PossibleTypeExtensionsRule.ts)
+- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/PossibleTypeExtensionsRule-test.ts)

--- a/docs/rules/unique-directive-names-per-location.md
+++ b/docs/rules/unique-directive-names-per-location.md
@@ -13,5 +13,5 @@ A GraphQL document is only valid if all non-repeatable directives at a given loc
 
 ## Resources
 
-- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/UniqueDirectiveNamesPerLocationRule.ts)
-- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/UniqueDirectiveNamesPerLocationRule-test.ts)
+- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/UniqueDirectivesPerLocationRule.ts)
+- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/UniqueDirectivesPerLocationRule-test.ts)

--- a/docs/rules/value-literals-of-correct-type.md
+++ b/docs/rules/value-literals-of-correct-type.md
@@ -13,5 +13,5 @@ A GraphQL document is only valid if all value literals are of the type expected 
 
 ## Resources
 
-- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/ValueLiteralsOfCorrectTypeRule.ts)
-- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/ValueLiteralsOfCorrectTypeRule-test.ts)
+- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/ValuesOfCorrectTypeRule.ts)
+- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts)

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -70,6 +70,7 @@ const validationToRule = (
       meta: {
         docs: {
           ...docs,
+          graphQLJSRuleName: ruleName,
           category: 'Validation',
           recommended: true,
           requiresSchema,

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -59,6 +59,7 @@ export type RuleDocsInfo<T> = Rule.RuleMetaData & {
       usage?: T;
     }[];
     optionsForConfig?: T;
+    graphQLJSRuleName?: string
   };
 };
 

--- a/packages/plugin/src/utils.ts
+++ b/packages/plugin/src/utils.ts
@@ -164,7 +164,7 @@ export enum CaseStyle {
   kebabCase = 'kebab-case',
 }
 
-export const pascalCase = (str: string): string =>
+const pascalCase = (str: string): string =>
   lowerCase(str)
     .split(' ')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -4,8 +4,6 @@ import dedent from 'dedent';
 import md from 'json-schema-to-markdown';
 import { format } from 'prettier';
 import { rules } from '../packages/plugin/src';
-import { pascalCase } from '../packages/plugin/src/utils';
-import { GRAPHQL_JS_VALIDATIONS } from '../packages/plugin/src/rules/graphql-js-validation';
 
 const BR = '';
 const DOCS_PATH = resolve(process.cwd(), 'docs');
@@ -63,7 +61,7 @@ function generateDocs(): void {
       );
     }
 
-    const { requiresSchema = false, requiresSiblings = false } = docs;
+    const { requiresSchema = false, requiresSiblings = false, graphQLJSRuleName } = docs;
 
     blocks.push(
       `- Category: \`${docs.category}\``,
@@ -111,13 +109,11 @@ function generateDocs(): void {
     }
 
     blocks.push(BR, '## Resources', BR);
-    const isGraphQLJSRule = ruleName in GRAPHQL_JS_VALIDATIONS;
 
-    if (isGraphQLJSRule) {
-      const graphQLJSRuleName = `${pascalCase(ruleName)}Rule`;
+    if (graphQLJSRuleName) {
       blocks.push(
-        `- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/${graphQLJSRuleName}.ts)`,
-        `- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/${graphQLJSRuleName}-test.ts)`
+        `- [Rule source](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/${graphQLJSRuleName}Rule.ts)`,
+        `- [Test source](https://github.com/graphql/graphql-js/tree/main/src/validation/__tests__/${graphQLJSRuleName}Rule-test.ts)`
       );
     } else {
       blocks.push(`- [Rule source](../../packages/plugin/src/rules/${ruleName}.ts)`);
@@ -145,7 +141,7 @@ function generateDocs(): void {
       return [
         link,
         docs.description.split('\n')[0],
-        ruleName in GRAPHQL_JS_VALIDATIONS ? Icon.GRAPHQL_JS : Icon.GRAPHQL_ESLINT,
+        docs.graphQLJSRuleName ? Icon.GRAPHQL_JS : Icon.GRAPHQL_ESLINT,
         fixable ? Icon.FIXABLE : '',
         docs.recommended ? Icon.RECOMMENDED : '',
       ];


### PR DESCRIPTION
so we can't use `pascalCase` function