### PR TITLE
fix: require-selections requireAllFields false positives

### DIFF
--- a/packages/plugin/src/rules/require-selections/index.test.ts
+++ b/packages/plugin/src/rules/require-selections/index.test.ts
@@ -55,6 +55,7 @@ const USER_POST_SCHEMA = /* GraphQL */ `
   type Post {
     id: ID
     title: String
+    content: String
     author: [User!]!
   }
 
@@ -316,6 +317,30 @@ ruleTester.run<RuleOptions, true>('require-selections', rule, {
         }
       `,
     },
+    {
+      name: 'should require only extant fields with `requireAllFields` option',
+        code: /* GraphQL */`
+            {
+              user {
+                id
+                posts {
+                  id
+                  title
+                  content
+                }
+              }
+            }
+          `,
+      options: [{ requireAllFields: true, fieldName: ['id', 'title', 'content'] }],
+      parserOptions: {
+        graphQLConfig: {
+          schema: USER_POST_SCHEMA,
+          documents: `
+          fragment Example on User { id }
+          `
+        },
+      },
+    },
   ],
   invalid: [
     {
@@ -523,7 +548,10 @@ ruleTester.run<RuleOptions, true>('require-selections', rule, {
           documents: '{ foo }',
         },
       },
-      errors: 1,
+      errors: [{
+    message: "Field `hasId.name` must be selected when it's available on a type.\n" +
+      'Include it in your selection set.',
+      }]
     },
   ],
 });

--- a/packages/plugin/src/rules/require-selections/index.test.ts
+++ b/packages/plugin/src/rules/require-selections/index.test.ts
@@ -319,25 +319,25 @@ ruleTester.run<RuleOptions, true>('require-selections', rule, {
     },
     {
       name: 'should require only extant fields with `requireAllFields` option',
-        code: /* GraphQL */`
-            {
-              user {
-                id
-                posts {
-                  id
-                  title
-                  content
-                }
-              }
+      code: /* GraphQL */ `
+        {
+          user {
+            id
+            posts {
+              id
+              title
+              content
             }
-          `,
+          }
+        }
+      `,
       options: [{ requireAllFields: true, fieldName: ['id', 'title', 'content'] }],
       parserOptions: {
         graphQLConfig: {
           schema: USER_POST_SCHEMA,
           documents: `
           fragment Example on User { id }
-          `
+          `,
         },
       },
     },
@@ -548,10 +548,13 @@ ruleTester.run<RuleOptions, true>('require-selections', rule, {
           documents: '{ foo }',
         },
       },
-      errors: [{
-    message: "Field `hasId.name` must be selected when it's available on a type.\n" +
-      'Include it in your selection set.',
-      }]
+      errors: [
+        {
+          message:
+            "Field `hasId.name` must be selected when it's available on a type.\n" +
+            'Include it in your selection set.',
+        },
+      ],
     },
   ],
 });

--- a/packages/plugin/src/rules/require-selections/index.ts
+++ b/packages/plugin/src/rules/require-selections/index.ts
@@ -201,20 +201,20 @@ export const rule: GraphQLESLintRule<RuleOptions, true> = {
 
       function checkFields(rawType: GraphQLInterfaceType | GraphQLObjectType) {
         const fields = rawType.getFields();
-        const hasIdFieldInType = idNames.some(name => fields[name]);
+        const idFieldsInType = idNames.filter(name => fields[name]);
 
-        if (!hasIdFieldInType) {
+        if (idFieldsInType.length === 0) {
           return;
         }
 
         checkFragments(node as GraphQLESTreeNode<SelectionSetNode>);
 
         if (requireAllFields) {
-          for (const idName of idNames) {
+          for (const idName of idFieldsInType) {
             report([idName]);
           }
         } else {
-          report(idNames);
+          report(idFieldsInType);
         }
       }
 

--- a/packages/plugin/src/rules/require-selections/index.ts
+++ b/packages/plugin/src/rules/require-selections/index.ts
@@ -201,8 +201,11 @@ export const rule: GraphQLESLintRule<RuleOptions, true> = {
 
       function checkFields(rawType: GraphQLInterfaceType | GraphQLObjectType) {
         const fields = rawType.getFields();
+
+        // Only check fields which are actually present on this type
         const idFieldsInType = idNames.filter(name => fields[name]);
 
+        // Type doesn't implement any of the `fieldNames`
         if (idFieldsInType.length === 0) {
           return;
         }
@@ -211,9 +214,13 @@ export const rule: GraphQLESLintRule<RuleOptions, true> = {
 
         if (requireAllFields) {
           for (const idName of idFieldsInType) {
+            // For each `fieldName` present on this type, check it's in the
+            // selection separately
             report([idName]);
           }
         } else {
+          // Pass the `fieldNames` present on this type together; `report` will
+          // pass if _any_ of them are selected
           report(idFieldsInType);
         }
       }


### PR DESCRIPTION
## Description

When using the `require-selections` rule with the `requireAllFields` option, a selection on a type that has _any_ of the `fieldNames` is demanded to include _all_ of the `fieldNames`, whether or not they exist on that type.

The issue lies in the `checkFields` function. It exits early if the type being inspected doesn't implement any of the `fieldNames` configured for the rule. Otherwise, it proceeds to report on _all_ of the `fieldNames` configured for the rule, not just the ones that exist on the type.

Fixes #2911

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

A unit test that fails without the update to the rule has been added.

**Test Environment**:

- OS: macOS
- `@graphql-eslint/...`: 4.4.0
- NodeJS: 22.7.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules