### PR TITLE
fix: Ignore client directives on fragments

### DIFF
--- a/packages/plugin/__tests__/__snapshots__/known-directives.spec.md
+++ b/packages/plugin/__tests__/__snapshots__/known-directives.spec.md
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`known-directives > invalid > should work only with Kind.FIELD 1`] = `
+exports[`known-directives > invalid > should not ignore directives on schema definitions 1`] = `
 #### ⌨️ Code
 
       1 | scalar Foo @bad

--- a/packages/plugin/__tests__/known-directives.spec.ts
+++ b/packages/plugin/__tests__/known-directives.spec.ts
@@ -1,6 +1,7 @@
 import { RuleTester } from '@theguild/eslint-rule-tester';
 import { GRAPHQL_JS_VALIDATIONS } from '../src/rules/graphql-js-validation.js';
-import { DEFAULT_CONFIG, ParserOptionsForTests } from './test-utils.js';
+import type { ParserOptionsForTests } from './test-utils.js';
+import { DEFAULT_CONFIG } from './test-utils.js';
 
 const ruleTester = new RuleTester<ParserOptionsForTests>({
   languageOptions: {
@@ -55,10 +56,47 @@ ruleTester.run<[{ ignoreClientDirectives: string[] }]>(
         `,
         options: [{ ignoreClientDirectives: ['api'] }],
       },
+      {
+        name: 'should ignore client directives on FragmentDefinition',
+        code: /* GraphQL */ `
+          fragment UserFields on User @client {
+            id
+          }
+        `,
+        options: [{ ignoreClientDirectives: ['client'] }],
+      },
+      {
+        name: 'should ignore client directives on InlineFragment',
+        code: /* GraphQL */ `
+          {
+            user {
+              ... on User @client {
+                id
+              }
+            }
+          }
+        `,
+        options: [{ ignoreClientDirectives: ['client'] }],
+      },
+      {
+        name: 'should ignore client directives on FragmentSpread',
+        code: /* GraphQL */ `
+          fragment UserFields on User {
+            id
+          }
+
+          {
+            user {
+              ...UserFields @client
+            }
+          }
+        `,
+        options: [{ ignoreClientDirectives: ['client'] }],
+      },
     ],
     invalid: [
       {
-        name: 'should work only with Kind.FIELD',
+        name: 'should not ignore directives on schema definitions',
         code: 'scalar Foo @bad',
         options: [{ ignoreClientDirectives: ['bad'] }],
         errors: [{ message: 'Unknown directive "@bad".' }],

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -309,6 +309,9 @@ export const GRAPHQL_JS_VALIDATIONS: Record<string, GraphQLESLintRule> = Object.
 
         return visit(documentNode, {
           Field: filterDirectives,
+          FragmentDefinition: filterDirectives,
+          FragmentSpread: filterDirectives,
+          InlineFragment: filterDirectives,
           OperationDefinition: filterDirectives,
         });
       },


### PR DESCRIPTION
## Description

The `ignoreClientDirectives` option for the `known-directives` rule only filters directives on `Field` and `OperationDefinition` nodes. It doesn't filter directives on `FragmentDefinition`, `FragmentSpread`, or `InlineFragment` nodes.

Fixes #2941

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added test cases to `packages/plugin/__tests__/known-directives.spec.ts`

**Test Environment**:

- OS: Mac Tahoe 26.1
- `@graphql-eslint/...`: 4.4.0
- NodeJS: v24.13.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
