### PR TITLE
fix: replace deprecated ESLint context methods for v10 compatibility

### DIFF
--- a/.changeset/eslint-10-compat.md
+++ b/.changeset/eslint-10-compat.md
@@ -1,0 +1,5 @@
+---
+"@graphql-eslint/eslint-plugin": patch
+---
+
+Replace deprecated `context.getSourceCode()` calls with `context.sourceCode ?? context.getSourceCode()` fallback for ESLint 10 compatibility

--- a/.changeset/eslint-10-compat.md
+++ b/.changeset/eslint-10-compat.md
@@ -2,4 +2,6 @@
 "@graphql-eslint/eslint-plugin": patch
 ---
 
-Replace deprecated `context.getSourceCode()` calls with `context.sourceCode ?? context.getSourceCode()` fallback for ESLint 10 compatibility
+Fix `TypeError: context.getSourceCode is not a function` when running with ESLint v10
+
+`context.getSourceCode()` was deprecated in ESLint v8.40 and removed in v10. All remaining call sites now use the `context.sourceCode` property, which is available in every supported ESLint version (peer dependency is `>=8.44.0`).

--- a/.changeset/eslint-10-compat.md
+++ b/.changeset/eslint-10-compat.md
@@ -1,7 +1,9 @@
 ---
-"@graphql-eslint/eslint-plugin": patch
+'@graphql-eslint/eslint-plugin': patch
 ---
 
 Fix `TypeError: context.getSourceCode is not a function` when running with ESLint v10
 
-`context.getSourceCode()` was deprecated in ESLint v8.40 and removed in v10. All remaining call sites now use the `context.sourceCode` property, which is available in every supported ESLint version (peer dependency is `>=8.44.0`).
+`context.getSourceCode()` was deprecated in ESLint v8.40 and removed in v10. All remaining call
+sites now use the `context.sourceCode` property, which is available in every supported ESLint
+version (peer dependency is `>=8.44.0`).

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
       "esbuild": "0.25.0",
       "@eslint/plugin-kit": "0.3.4",
       "cookie": "0.7.0",
-      "glob": "11.1.0"
+      "glob": "11.1.0",
+      "eslint-plugin-unicorn": "56.0.1",
+      "eslint-plugin-mdx": "3.8.1"
     }
   }
 }

--- a/packages/plugin/src/rules/alphabetize/index.ts
+++ b/packages/plugin/src/rules/alphabetize/index.ts
@@ -219,7 +219,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
     schema,
   },
   create(context) {
-    const sourceCode = context.getSourceCode();
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
 
     function isNodeAndCommentOnSameLine(node: { loc: SourceLocation }, comment: Comment): boolean {
       return node.loc.end.line === comment.loc!.start.line;

--- a/packages/plugin/src/rules/alphabetize/index.ts
+++ b/packages/plugin/src/rules/alphabetize/index.ts
@@ -219,7 +219,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
     schema,
   },
   create(context) {
-    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const sourceCode = context.sourceCode;
 
     function isNodeAndCommentOnSameLine(node: { loc: SourceLocation }, comment: Comment): boolean {
       return node.loc.end.line === comment.loc!.start.line;

--- a/packages/plugin/src/rules/alphabetize/index.ts
+++ b/packages/plugin/src/rules/alphabetize/index.ts
@@ -219,7 +219,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
     schema,
   },
   create(context) {
-    const sourceCode = context.sourceCode;
+    const { sourceCode } = context;
 
     function isNodeAndCommentOnSameLine(node: { loc: SourceLocation }, comment: Comment): boolean {
       return node.loc.end.line === comment.loc!.start.line;

--- a/packages/plugin/src/rules/description-style/index.ts
+++ b/packages/plugin/src/rules/description-style/index.ts
@@ -72,7 +72,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
             {
               desc: `Change to ${isBlock ? 'block' : 'inline'} style description`,
               fix(fixer) {
-                const sourceCode = context.getSourceCode();
+                const sourceCode = context.sourceCode ?? context.getSourceCode();
                 const originalText = sourceCode.getText(node as any);
                 const newText = isBlock
                   ? originalText.replace(/(^")|("$)/g, '"""')

--- a/packages/plugin/src/rules/description-style/index.ts
+++ b/packages/plugin/src/rules/description-style/index.ts
@@ -72,7 +72,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
             {
               desc: `Change to ${isBlock ? 'block' : 'inline'} style description`,
               fix(fixer) {
-                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const sourceCode = context.sourceCode;
                 const originalText = sourceCode.getText(node as any);
                 const newText = isBlock
                   ? originalText.replace(/(^")|("$)/g, '"""')

--- a/packages/plugin/src/rules/description-style/index.ts
+++ b/packages/plugin/src/rules/description-style/index.ts
@@ -72,7 +72,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
             {
               desc: `Change to ${isBlock ? 'block' : 'inline'} style description`,
               fix(fixer) {
-                const sourceCode = context.sourceCode;
+                const { sourceCode } = context;
                 const originalText = sourceCode.getText(node as any);
                 const newText = isBlock
                   ? originalText.replace(/(^")|("$)/g, '"""')

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -80,7 +80,7 @@ function validateDocument({
 
     for (const error of validationErrors) {
       const { line, column } = error.locations![0];
-      const sourceCode = context.getSourceCode();
+      const sourceCode = context.sourceCode ?? context.getSourceCode();
       const { tokens } = sourceCode.ast;
       const token = tokens.find(
         token => token.loc.start.line === line && token.loc.start.column === column - 1,

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -80,7 +80,7 @@ function validateDocument({
 
     for (const error of validationErrors) {
       const { line, column } = error.locations![0];
-      const sourceCode = context.sourceCode ?? context.getSourceCode();
+      const sourceCode = context.sourceCode;
       const { tokens } = sourceCode.ast;
       const token = tokens.find(
         token => token.loc.start.line === line && token.loc.start.column === column - 1,

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -80,7 +80,7 @@ function validateDocument({
 
     for (const error of validationErrors) {
       const { line, column } = error.locations![0];
-      const sourceCode = context.sourceCode;
+      const { sourceCode } = context;
       const { tokens } = sourceCode.ast;
       const token = tokens.find(
         token => token.loc.start.line === line && token.loc.start.column === column - 1,

--- a/packages/plugin/src/rules/no-anonymous-operations/index.ts
+++ b/packages/plugin/src/rules/no-anonymous-operations/index.ts
@@ -59,7 +59,7 @@ export const rule: GraphQLESLintRule = {
             {
               desc: `Rename to \`${suggestedName}\``,
               fix(fixer) {
-                const sourceCode = context.getSourceCode();
+                const sourceCode = context.sourceCode ?? context.getSourceCode();
                 const hasQueryKeyword =
                   sourceCode.getText({ range: [node.range[0], node.range[0] + 1] } as any) !== '{';
 

--- a/packages/plugin/src/rules/no-anonymous-operations/index.ts
+++ b/packages/plugin/src/rules/no-anonymous-operations/index.ts
@@ -59,7 +59,7 @@ export const rule: GraphQLESLintRule = {
             {
               desc: `Rename to \`${suggestedName}\``,
               fix(fixer) {
-                const sourceCode = context.sourceCode;
+                const { sourceCode } = context;
                 const hasQueryKeyword =
                   sourceCode.getText({ range: [node.range[0], node.range[0] + 1] } as any) !== '{';
 

--- a/packages/plugin/src/rules/no-anonymous-operations/index.ts
+++ b/packages/plugin/src/rules/no-anonymous-operations/index.ts
@@ -59,7 +59,7 @@ export const rule: GraphQLESLintRule = {
             {
               desc: `Rename to \`${suggestedName}\``,
               fix(fixer) {
-                const sourceCode = context.sourceCode ?? context.getSourceCode();
+                const sourceCode = context.sourceCode;
                 const hasQueryKeyword =
                   sourceCode.getText({ range: [node.range[0], node.range[0] + 1] } as any) !== '{';
 

--- a/packages/plugin/src/rules/no-hashtag-description/index.ts
+++ b/packages/plugin/src/rules/no-hashtag-description/index.ts
@@ -75,7 +75,7 @@ export const rule: GraphQLESLintRule = {
               next.kind === TokenKind.NAME &&
               linesAfter < 2
             ) {
-              const sourceCode = context.getSourceCode();
+              const sourceCode = context.sourceCode ?? context.getSourceCode();
               const { tokens } = sourceCode.ast;
 
               const t = tokens.find(

--- a/packages/plugin/src/rules/no-hashtag-description/index.ts
+++ b/packages/plugin/src/rules/no-hashtag-description/index.ts
@@ -75,7 +75,7 @@ export const rule: GraphQLESLintRule = {
               next.kind === TokenKind.NAME &&
               linesAfter < 2
             ) {
-              const sourceCode = context.sourceCode ?? context.getSourceCode();
+              const sourceCode = context.sourceCode;
               const { tokens } = sourceCode.ast;
 
               const t = tokens.find(

--- a/packages/plugin/src/rules/no-hashtag-description/index.ts
+++ b/packages/plugin/src/rules/no-hashtag-description/index.ts
@@ -75,7 +75,7 @@ export const rule: GraphQLESLintRule = {
               next.kind === TokenKind.NAME &&
               linesAfter < 2
             ) {
-              const sourceCode = context.sourceCode;
+              const { sourceCode } = context;
               const { tokens } = sourceCode.ast;
 
               const t = tokens.find(

--- a/packages/plugin/src/rules/no-unused-fields/index.ts
+++ b/packages/plugin/src/rules/no-unused-fields/index.ts
@@ -237,7 +237,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
             {
               desc: `Remove \`${fieldName}\` field`,
               fix(fixer) {
-                const sourceCode = context.getSourceCode() as any;
+                const sourceCode = (context.sourceCode ?? context.getSourceCode()) as any;
                 const tokenBefore = sourceCode.getTokenBefore(node);
                 const tokenAfter = sourceCode.getTokenAfter(node);
                 const isEmptyType = tokenBefore.type === '{' && tokenAfter.type === '}';

--- a/packages/plugin/src/rules/no-unused-fields/index.ts
+++ b/packages/plugin/src/rules/no-unused-fields/index.ts
@@ -237,7 +237,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
             {
               desc: `Remove \`${fieldName}\` field`,
               fix(fixer) {
-                const sourceCode = (context.sourceCode ?? context.getSourceCode()) as any;
+                const sourceCode = context.sourceCode as any;
                 const tokenBefore = sourceCode.getTokenBefore(node);
                 const tokenAfter = sourceCode.getTokenAfter(node);
                 const isEmptyType = tokenBefore.type === '{' && tokenAfter.type === '}';

--- a/packages/plugin/src/rules/require-import-fragment/index.ts
+++ b/packages/plugin/src/rules/require-import-fragment/index.ts
@@ -69,7 +69,7 @@ export const rule: GraphQLESLintRule = {
     schema: [],
   },
   create(context) {
-    const comments = context.getSourceCode().getAllComments();
+    const comments = (context.sourceCode ?? context.getSourceCode()).getAllComments();
     const siblings = requireGraphQLOperations(RULE_ID, context);
     const filePath = context.filename;
 

--- a/packages/plugin/src/rules/require-import-fragment/index.ts
+++ b/packages/plugin/src/rules/require-import-fragment/index.ts
@@ -69,7 +69,7 @@ export const rule: GraphQLESLintRule = {
     schema: [],
   },
   create(context) {
-    const comments = (context.sourceCode ?? context.getSourceCode()).getAllComments();
+    const comments = context.sourceCode.getAllComments();
     const siblings = requireGraphQLOperations(RULE_ID, context);
     const filePath = context.filename;
 

--- a/packages/plugin/src/rules/require-nullable-result-in-root/index.ts
+++ b/packages/plugin/src/rules/require-nullable-result-in-root/index.ts
@@ -45,7 +45,7 @@ export const rule: GraphQLESLintRule = {
     const rootTypeNames = new Set(
       [schema.getQueryType(), schema.getMutationType()].filter(v => !!v).map(type => type.name),
     );
-    const sourceCode = context.getSourceCode();
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
 
     return {
       'ObjectTypeDefinition,ObjectTypeExtension'(

--- a/packages/plugin/src/rules/require-nullable-result-in-root/index.ts
+++ b/packages/plugin/src/rules/require-nullable-result-in-root/index.ts
@@ -45,7 +45,7 @@ export const rule: GraphQLESLintRule = {
     const rootTypeNames = new Set(
       [schema.getQueryType(), schema.getMutationType()].filter(v => !!v).map(type => type.name),
     );
-    const sourceCode = context.sourceCode;
+    const { sourceCode } = context;
 
     return {
       'ObjectTypeDefinition,ObjectTypeExtension'(

--- a/packages/plugin/src/rules/require-nullable-result-in-root/index.ts
+++ b/packages/plugin/src/rules/require-nullable-result-in-root/index.ts
@@ -45,7 +45,7 @@ export const rule: GraphQLESLintRule = {
     const rootTypeNames = new Set(
       [schema.getQueryType(), schema.getMutationType()].filter(v => !!v).map(type => type.name),
     );
-    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const sourceCode = context.sourceCode;
 
     return {
       'ObjectTypeDefinition,ObjectTypeExtension'(

--- a/packages/plugin/src/rules/selection-set-depth/index.ts
+++ b/packages/plugin/src/rules/selection-set-depth/index.ts
@@ -131,7 +131,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
                     {
                       desc: 'Remove selections',
                       fix(fixer) {
-                        const sourceCode = context.getSourceCode();
+                        const sourceCode = context.sourceCode ?? context.getSourceCode();
                         const foundNode = sourceCode.getNodeByRangeIndex(token.range[0]) as any;
                         const parentNode = foundNode.parent.parent;
                         return fixer.remove(

--- a/packages/plugin/src/rules/selection-set-depth/index.ts
+++ b/packages/plugin/src/rules/selection-set-depth/index.ts
@@ -131,7 +131,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
                     {
                       desc: 'Remove selections',
                       fix(fixer) {
-                        const sourceCode = context.sourceCode;
+                        const { sourceCode } = context;
                         const foundNode = sourceCode.getNodeByRangeIndex(token.range[0]) as any;
                         const parentNode = foundNode.parent.parent;
                         return fixer.remove(

--- a/packages/plugin/src/rules/selection-set-depth/index.ts
+++ b/packages/plugin/src/rules/selection-set-depth/index.ts
@@ -131,7 +131,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
                     {
                       desc: 'Remove selections',
                       fix(fixer) {
-                        const sourceCode = context.sourceCode ?? context.getSourceCode();
+                        const sourceCode = context.sourceCode;
                         const foundNode = sourceCode.getNodeByRangeIndex(token.range[0]) as any;
                         const parentNode = foundNode.parent.parent;
                         return fixer.remove(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   '@eslint/plugin-kit': 0.3.4
   cookie: 0.7.0
   glob: 11.1.0
+  eslint-plugin-unicorn: 56.0.1
+  eslint-plugin-mdx: 3.8.1
 
 patchedDependencies:
   eslint:
@@ -2097,9 +2099,9 @@ packages:
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@pkgr/core@0.2.9':
-    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+  '@pkgr/core@0.3.6':
+    resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3391,10 +3393,6 @@ packages:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
 
-  builtin-modules@4.0.0:
-    resolution: {integrity: sha512-p1n8zyCkt1BVrKNFymOHjcDSAl7oq/gUvfgULv2EblgpPVQlQr9yHnWjg9IJ2MhfwPqiYqMMrr01OY7yQoK2yA==}
-    engines: {node: '>=18.20'}
-
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3925,10 +3923,6 @@ packages:
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
-  diff@5.2.0:
-    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
-    engines: {node: '>=0.3.1'}
-
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -4134,8 +4128,8 @@ packages:
       '@eslint/json':
         optional: true
 
-  eslint-mdx@3.6.2:
-    resolution: {integrity: sha512-5hczn5iSSEcwtNtVXFwCKIk6iLEDaZpwc3vjYDl/B779OzaAAK/ou16J2xVdO6ecOLEO1WZqp7MRCQ/WsKDUig==}
+  eslint-mdx@3.8.1:
+    resolution: {integrity: sha512-hnsqWwMOHqUANwxWEGt8XbwABPEr5sTOolAzqyUDFdlERpqjFE/icylb+mJl60VICL+kLbbvXWbnFLWZdTqJ2g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       eslint: 9.22.0
@@ -4204,8 +4198,8 @@ packages:
     peerDependencies:
       eslint: 9.22.0
 
-  eslint-plugin-mdx@3.2.0:
-    resolution: {integrity: sha512-zMD6DoFf5tj86dF1M0g90IxeBzrckyhYwksvalO1vfOBPPzhpR2wAbILBHZnubNuQALVgiqYQbPQ922GpviuGA==}
+  eslint-plugin-mdx@3.8.1:
+    resolution: {integrity: sha512-4OLgotfBxUDc1f6ihXSagT/1+JCCUABA/2r6Kzl6gqFftg4dCV0wBfdwFo6X6UO/FzTHr3g6mVt+6prRXffc/Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       eslint: 9.22.0
@@ -4259,8 +4253,8 @@ packages:
     peerDependencies:
       tailwindcss: ^3.4.0
 
-  eslint-plugin-unicorn@57.0.0:
-    resolution: {integrity: sha512-zUYYa6zfNdTeG9BISWDlcLmz16c+2Ck2o5ZDHh0UzXJz3DEP7xjmlVDTzbyV0W+XksgZ0q37WEWzN2D2Ze+g9Q==}
+  eslint-plugin-unicorn@56.0.1:
+    resolution: {integrity: sha512-FwVV0Uwf8XPfVnKSGpMg7NtlZh0G0gBarCaFcMUOoqPxXryxdYxTRRv4kH6B9TFCVIrjRXG+emcxIk2ayZilog==}
     engines: {node: '>=18.18'}
     peerDependencies:
       eslint: 9.22.0
@@ -4467,10 +4461,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  find-up-simple@1.0.1:
-    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
-    engines: {node: '>=18'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -4742,6 +4732,9 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -4787,13 +4780,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  indent-string@5.0.0:
-    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
-    engines: {node: '>=12'}
-
-  index-to-position@1.1.0:
-    resolution: {integrity: sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==}
-    engines: {node: '>=18'}
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4848,9 +4837,9 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
-  is-builtin-module@4.0.0:
-    resolution: {integrity: sha512-rWP3AMAalQSesXO8gleROyL2iKU73SX5Er66losQn9rWOWL4Gef0a/xOEOVqjWGMuR2vHG3FJ8UUmT700O8oFg==}
-    engines: {node: '>=18.20'}
+  is-builtin-module@3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
+    engines: {node: '>=6'}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -5048,6 +5037,10 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsesc@0.5.0:
+    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
+    hasBin: true
+
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
     engines: {node: '>=6'}
@@ -5113,10 +5106,6 @@ packages:
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
-
-  kleur@4.1.5:
-    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
-    engines: {node: '>=6'}
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -5715,6 +5704,9 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     hasBin: true
 
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -5874,10 +5866,6 @@ packages:
   parse-json@7.1.1:
     resolution: {integrity: sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==}
     engines: {node: '>=16'}
-
-  parse-json@8.3.0:
-    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
-    engines: {node: '>=18'}
 
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
@@ -6260,13 +6248,13 @@ packages:
     resolution: {integrity: sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  read-package-up@11.0.0:
-    resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
-    engines: {node: '>=18'}
+  read-pkg-up@7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
 
-  read-pkg@9.0.1:
-    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
-    engines: {node: '>=18'}
+  read-pkg@5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -6341,6 +6329,10 @@ packages:
 
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
+
+  regjsparser@0.10.0:
+    resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
+    hasBin: true
 
   regjsparser@0.12.0:
     resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
@@ -6469,10 +6461,6 @@ packages:
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
-  sade@1.8.1:
-    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
-    engines: {node: '>=6'}
-
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -6504,6 +6492,10 @@ packages:
   scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
     engines: {node: ^14.0.0 || >=16.0.0}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -6730,9 +6722,9 @@ packages:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
-  strip-indent@4.0.0:
-    resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
-    engines: {node: '>=12'}
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -6816,8 +6808,8 @@ packages:
     resolution: {integrity: sha512-c7AfkZ9udatCuAy9RSfiGPpeOKKUAUK5e1cXadLOGUjasdxqYqAK0jTNkM/FSEyJ3a5Ra27j/tw/PS0qLmaF/A==}
     engines: {node: '>=18'}
 
-  synckit@0.11.11:
-    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
+  synckit@0.11.13:
+    resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
   synckit@0.6.2:
@@ -7048,13 +7040,17 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+
+  type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
+
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
-
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -7121,10 +7117,6 @@ packages:
   unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
-
-  unicorn-magic@0.1.0:
-    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
-    engines: {node: '>=18'}
 
   unified-engine@11.2.2:
     resolution: {integrity: sha512-15g/gWE7qQl9tQ3nAEbMd5h9HV1EACtFs6N9xaRBZICoCwnNGbal1kOs++ICf4aiTdItZxU2s/kYWhW7htlqJg==}
@@ -7234,11 +7226,6 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    hasBin: true
-
-  uvu@0.5.6:
-    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
-    engines: {node: '>=8'}
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -9517,7 +9504,7 @@ snapshots:
 
   '@pkgr/core@0.1.2': {}
 
-  '@pkgr/core@0.2.9': {}
+  '@pkgr/core@0.3.6': {}
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -10081,13 +10068,13 @@ snapshots:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.2.1)(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       eslint-plugin-jsonc: 2.19.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
-      eslint-plugin-mdx: 3.2.0(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
+      eslint-plugin-mdx: 3.8.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       eslint-plugin-n: 17.16.2(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       eslint-plugin-promise: 7.2.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       eslint-plugin-react: 7.37.4(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       eslint-plugin-sonarjs: 3.0.2(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
-      eslint-plugin-unicorn: 57.0.0(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
+      eslint-plugin-unicorn: 56.0.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       eslint-plugin-yml: 1.17.0(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -10917,8 +10904,6 @@ snapshots:
 
   builtin-modules@3.3.0: {}
 
-  builtin-modules@4.0.0: {}
-
   bundle-require@5.1.0(esbuild@0.25.0):
     dependencies:
       esbuild: 0.25.0
@@ -11447,8 +11432,6 @@ snapshots:
 
   didyoumean@1.2.2: {}
 
-  diff@5.2.0: {}
-
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -11730,7 +11713,7 @@ snapshots:
       esquery: 1.6.0
       jsonc-eslint-parser: 2.4.0
 
-  eslint-mdx@3.6.2(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1)):
+  eslint-mdx@3.8.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1)):
     dependencies:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
@@ -11740,11 +11723,10 @@ snapshots:
       remark-mdx: 3.1.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
-      synckit: 0.11.11
+      synckit: 0.11.13
       unified: 11.0.5
       unified-engine: 11.2.2
       unist-util-visit: 5.0.0
-      uvu: 0.5.6
       vfile: 6.0.3
     transitivePeerDependencies:
       - bluebird
@@ -11840,16 +11822,17 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-mdx@3.2.0(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1)):
+  eslint-plugin-mdx@3.8.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1)):
     dependencies:
       eslint: 9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1)
-      eslint-mdx: 3.6.2(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
+      eslint-mdx: 3.8.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
       mdast-util-from-markdown: 2.0.2
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
       remark-mdx: 3.1.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
-      synckit: 0.9.3
-      tslib: 2.8.1
+      synckit: 0.11.13
       unified: 11.0.5
       vfile: 6.0.3
     transitivePeerDependencies:
@@ -11929,7 +11912,7 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 3.4.17
 
-  eslint-plugin-unicorn@57.0.0(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1)):
+  eslint-plugin-unicorn@56.0.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1)):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))
@@ -11939,15 +11922,15 @@ snapshots:
       eslint: 9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1)
       esquery: 1.6.0
       globals: 15.15.0
-      indent-string: 5.0.0
-      is-builtin-module: 4.0.0
+      indent-string: 4.0.0
+      is-builtin-module: 3.2.1
       jsesc: 3.1.0
       pluralize: 8.0.0
-      read-package-up: 11.0.0
+      read-pkg-up: 7.0.1
       regexp-tree: 0.1.27
-      regjsparser: 0.12.0
+      regjsparser: 0.10.0
       semver: 7.7.2
-      strip-indent: 4.0.0
+      strip-indent: 3.0.0
 
   eslint-plugin-vue@10.3.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))(typescript@5.8.3))(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))(vue-eslint-parser@9.4.3(eslint@9.22.0(patch_hash=cb00d0a959512dc3ccdfa2be3c84743c7edf6fb8e7593371f0b2a9588a2b969f)(jiti@2.5.1))):
     dependencies:
@@ -12190,8 +12173,6 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  find-up-simple@1.0.1: {}
 
   find-up@4.1.0:
     dependencies:
@@ -12567,6 +12548,8 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
+  hosted-git-info@2.8.9: {}
+
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -12600,9 +12583,7 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  indent-string@5.0.0: {}
-
-  index-to-position@1.1.0: {}
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -12659,9 +12640,9 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  is-builtin-module@4.0.0:
+  is-builtin-module@3.2.1:
     dependencies:
-      builtin-modules: 4.0.0
+      builtin-modules: 3.3.0
 
   is-callable@1.2.7: {}
 
@@ -12835,6 +12816,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@0.5.0: {}
+
   jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
@@ -12891,8 +12874,6 @@ snapshots:
       json-buffer: 3.0.1
 
   khroma@2.1.0: {}
-
-  kleur@4.1.5: {}
 
   kolorist@1.8.0: {}
 
@@ -13815,6 +13796,13 @@ snapshots:
     dependencies:
       abbrev: 2.0.0
 
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.10
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
@@ -14002,12 +13990,6 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       lines-and-columns: 2.0.4
       type-fest: 3.13.1
-
-  parse-json@8.3.0:
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      index-to-position: 1.1.0
-      type-fest: 4.41.0
 
   parse-latin@7.0.0:
     dependencies:
@@ -14296,19 +14278,18 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       npm-normalize-package-bin: 3.0.1
 
-  read-package-up@11.0.0:
+  read-pkg-up@7.0.1:
     dependencies:
-      find-up-simple: 1.0.1
-      read-pkg: 9.0.1
-      type-fest: 4.41.0
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
 
-  read-pkg@9.0.1:
+  read-pkg@5.2.0:
     dependencies:
       '@types/normalize-package-data': 2.4.4
-      normalize-package-data: 6.0.2
-      parse-json: 8.3.0
-      type-fest: 4.41.0
-      unicorn-magic: 0.1.0
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -14419,6 +14400,10 @@ snapshots:
       unicode-match-property-value-ecmascript: 2.2.0
 
   regjsgen@0.8.0: {}
+
+  regjsparser@0.10.0:
+    dependencies:
+      jsesc: 0.5.0
 
   regjsparser@0.12.0:
     dependencies:
@@ -14654,10 +14639,6 @@ snapshots:
 
   rw@1.3.3: {}
 
-  sade@1.8.1:
-    dependencies:
-      mri: 1.2.0
-
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -14701,6 +14682,8 @@ snapshots:
       '@eslint-community/regexpp': 4.12.1
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
+
+  semver@5.7.2: {}
 
   semver@6.3.1: {}
 
@@ -15023,7 +15006,7 @@ snapshots:
 
   strip-final-newline@3.0.0: {}
 
-  strip-indent@4.0.0:
+  strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
 
@@ -15126,9 +15109,9 @@ snapshots:
       timeout-signal: 2.0.0
       whatwg-mimetype: 4.0.0
 
-  synckit@0.11.11:
+  synckit@0.11.13:
     dependencies:
-      '@pkgr/core': 0.2.9
+      '@pkgr/core': 0.3.6
 
   synckit@0.6.2:
     dependencies:
@@ -15352,9 +15335,11 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@3.13.1: {}
+  type-fest@0.6.0: {}
 
-  type-fest@4.41.0: {}
+  type-fest@0.8.1: {}
+
+  type-fest@3.13.1: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -15431,8 +15416,6 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.1.0: {}
 
-  unicorn-magic@0.1.0: {}
-
   unified-engine@11.2.2:
     dependencies:
       '@types/concat-stream': 2.0.3
@@ -15455,7 +15438,7 @@ snapshots:
       vfile-message: 4.0.3
       vfile-reporter: 8.1.1
       vfile-statistics: 3.0.0
-      yaml: 2.8.0
+      yaml: 2.8.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -15593,13 +15576,6 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@9.0.1: {}
-
-  uvu@0.5.6:
-    dependencies:
-      dequal: 2.0.3
-      diff: 5.2.0
-      kleur: 4.1.5
-      sade: 1.8.1
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
## Summary

Replaces all occurrences of the deprecated `context.getSourceCode()` method with the `context.sourceCode` property (with `??` fallback) across 9 rule files. This fixes the `TypeError: context.getSourceCode is not a function` crash when using `@graphql-eslint/eslint-plugin` with ESLint 10.

### What changed

All 9 rule files that called `context.getSourceCode()` were updated to use `context.sourceCode ?? context.getSourceCode()`:
- `alphabetize/index.ts`
- `description-style/index.ts`
- `graphql-js-validation.ts`
- `no-anonymous-operations/index.ts`
- `no-hashtag-description/index.ts`
- `no-unused-fields/index.ts`
- `require-import-fragment/index.ts`
- `require-nullable-result-in-root/index.ts`
- `selection-set-depth/index.ts`

### Why

`context.getSourceCode()` was deprecated in ESLint v8.40 and removed in ESLint v10. The `context.sourceCode` property has been available since v8.40 and is already used elsewhere in the codebase (e.g., `utils.ts`).

The `??` fallback ensures backward compatibility with all currently supported ESLint versions.

Reference: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/

### Testing

All 78 targeted rule tests pass. The 2 failures in `require-deprecation-date` are pre-existing (time-sensitive fixture) and unrelated to this change.

Fixes #2945