### PR TITLE
fix: `RuleDocsInfo` type mismatch with eslint type

### DIFF
--- a/packages/plugin/src/rules/alphabetize/index.ts
+++ b/packages/plugin/src/rules/alphabetize/index.ts
@@ -112,7 +112,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
     type: 'suggestion',
     fixable: 'code',
     docs: {
-      category: ['Schema', 'Operations'],
+      category: 'Schema-and-operations',
       description:
         'Enforce arrange in alphabetical order for type fields, enum values, input object fields, operation selections and more.',
       url: `https://the-guild.dev/graphql/eslint/rules/${RULE_ID}`,

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -284,7 +284,7 @@ export const GRAPHQL_JS_VALIDATIONS: Record<string, GraphQLESLintRule> = Object.
       hasDidYouMeanSuggestions: true,
     },
     {
-      category: ['Schema', 'Operations'],
+      category: 'Schema-and-operations',
       description:
         'A GraphQL field is only valid if all supplied arguments are defined by that field.',
       requiresSchema: true,
@@ -326,7 +326,7 @@ export const GRAPHQL_JS_VALIDATIONS: Record<string, GraphQLESLintRule> = Object.
       },
     },
     {
-      category: ['Schema', 'Operations'],
+      category: 'Schema-and-operations',
       description:
         'A GraphQL document is only valid if all `@directive`s are known by the schema and legally positioned.',
       requiresSchema: true,
@@ -412,7 +412,7 @@ export const GRAPHQL_JS_VALIDATIONS: Record<string, GraphQLESLintRule> = Object.
       hasDidYouMeanSuggestions: true,
     },
     {
-      category: ['Schema', 'Operations'],
+      category: 'Schema-and-operations',
       description:
         'A GraphQL document is only valid if referenced types (specifically variable definitions and fragment conditions) are defined by the type schema.',
       requiresSchema: true,
@@ -576,7 +576,7 @@ export const GRAPHQL_JS_VALIDATIONS: Record<string, GraphQLESLintRule> = Object.
       rule: ProvidedRequiredArgumentsRule,
     },
     {
-      category: ['Schema', 'Operations'],
+      category: 'Schema-and-operations',
       description:
         'A field or directive is only valid if all required (non-null without a default value) field arguments have been provided.',
       requiresSchema: true,
@@ -634,7 +634,7 @@ export const GRAPHQL_JS_VALIDATIONS: Record<string, GraphQLESLintRule> = Object.
       rule: UniqueDirectivesPerLocationRule,
     },
     {
-      category: ['Schema', 'Operations'],
+      category: 'Schema-and-operations',
       description:
         'A GraphQL document is only valid if all non-repeatable directives at a given location are uniquely named.',
       requiresSchema: true,

--- a/packages/plugin/src/rules/naming-convention/index.ts
+++ b/packages/plugin/src/rules/naming-convention/index.ts
@@ -169,7 +169,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
     type: 'suggestion',
     docs: {
       description: 'Require names to follow specified conventions.',
-      category: ['Schema', 'Operations'],
+      category: 'Schema-and-operations',
       recommended: true,
       url: 'https://the-guild.dev/graphql/eslint/rules/naming-convention',
       examples: [

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -52,7 +52,7 @@ export type CategoryType = 'Operations' | 'Schema';
 type RuleMetaDataDocs = Required<Rule.RuleMetaData>['docs'];
 
 export type RuleDocsInfo<T> = Omit<RuleMetaDataDocs, 'category' | 'suggestion'> & {
-  category: CategoryType | CategoryType[];
+  category: CategoryType;
   requiresSchema?: true;
   requiresSiblings?: true;
   examples?: {

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -47,7 +47,7 @@ export type GraphQLESLintRuleContext<Options = any[]> = Omit<
   report(descriptor: ReportDescriptor): void;
 };
 
-export type CategoryType = 'Operations' | 'Schema' | 'Both';
+export type CategoryType = 'Operations' | 'Schema' | 'Schema-and-operations';
 
 type RuleMetaDataDocs = Required<Rule.RuleMetaData>['docs'];
 

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -47,7 +47,7 @@ export type GraphQLESLintRuleContext<Options = any[]> = Omit<
   report(descriptor: ReportDescriptor): void;
 };
 
-export type CategoryType = 'Operations' | 'Schema';
+export type CategoryType = 'Operations' | 'Schema' | 'Both';
 
 type RuleMetaDataDocs = Required<Rule.RuleMetaData>['docs'];
 

--- a/website/content/rules/alphabetize.mdx
+++ b/website/content/rules/alphabetize.mdx
@@ -10,7 +10,7 @@ description:
 [command line](https://eslint.org/docs/user-guide/command-line-interface#--fix) can automatically
 fix some of the problems reported by this rule.
 
-- Category: `Schema & Operations`
+- Category: `Schema-and-operations`
 - Rule name: `@graphql-eslint/alphabetize`
 - Requires GraphQL Schema: `false`
   [ℹ️](/docs/getting-started#extended-linting-rules-with-graphql-schema)

--- a/website/content/rules/index.md
+++ b/website/content/rules/index.md
@@ -15,21 +15,21 @@ Each rule has emojis denoting:
 <!-- prettier-ignore -->
 Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|&nbsp;&nbsp;&nbsp;&nbsp;Config&nbsp;&nbsp;&nbsp;&nbsp;|📄&nbsp;/&nbsp;📦|🚀&nbsp;/&nbsp;🔮|🔧&nbsp;/&nbsp;💡
 -|-|:-:|:-:|:-:|:-:
-[alphabetize](/rules/alphabetize)|Enforce arrange in alphabetical order for type fields, enum values, input object fields, operation selections and more.|![all][]|📄 📦|🚀|🔧
+[alphabetize](/rules/alphabetize)|Enforce arrange in alphabetical order for type fields, enum values, input object fields, operation selections and more.|![all][]||🚀|🔧
 [description-style](/rules/description-style)|Require all comments to follow the same style (either block or inline).|![recommended][]|📄|🚀|💡
 [executable-definitions](/rules/executable-definitions)|A GraphQL document is only valid for execution if all definitions are either operation or fragment definitions.|![recommended][]|📦|🔮|
 [fields-on-correct-type](/rules/fields-on-correct-type)|A GraphQL document is only valid if all fields selected are defined by the parent type, or are an allowed meta field such as `__typename`.|![recommended][]|📦|🔮|💡
 [fragments-on-composite-type](/rules/fragments-on-composite-type)|Fragments use a type condition to determine if they apply, since fragments can only be spread into a composite type (object, interface, or union), the type condition must also be a composite type.|![recommended][]|📦|🔮|
 [input-name](/rules/input-name)|Require mutation argument to be always called "input" and input type to be called Mutation name + "Input".|![all][]|📄|🚀|💡
-[known-argument-names](/rules/known-argument-names)|A GraphQL field is only valid if all supplied arguments are defined by that field.|![recommended][]|📄 📦|🔮|💡
-[known-directives](/rules/known-directives)|A GraphQL document is only valid if all `@directive`s are known by the schema and legally positioned.|![recommended][]|📄 📦|🔮|
+[known-argument-names](/rules/known-argument-names)|A GraphQL field is only valid if all supplied arguments are defined by that field.|![recommended][]||🔮|💡
+[known-directives](/rules/known-directives)|A GraphQL document is only valid if all `@directive`s are known by the schema and legally positioned.|![recommended][]||🔮|
 [known-fragment-names](/rules/known-fragment-names)|A GraphQL document is only valid if all `...Fragment` fragment spreads refer to fragments defined in the same document.|![recommended][]|📦|🔮|
-[known-type-names](/rules/known-type-names)|A GraphQL document is only valid if referenced types (specifically variable definitions and fragment conditions) are defined by the type schema.|![recommended][]|📄 📦|🔮|💡
+[known-type-names](/rules/known-type-names)|A GraphQL document is only valid if referenced types (specifically variable definitions and fragment conditions) are defined by the type schema.|![recommended][]||🔮|💡
 [lone-anonymous-operation](/rules/lone-anonymous-operation)|A GraphQL document that contains an anonymous operation (the `query` short-hand) is only valid if it contains only that one operation definition.|![recommended][]|📦|🔮|
 [lone-executable-definition](/rules/lone-executable-definition)|Require queries, mutations, subscriptions or fragments to be located in separate files.|![all][]|📦|🚀|
 [lone-schema-definition](/rules/lone-schema-definition)|A GraphQL document is only valid if it contains only one schema definition.|![recommended][]|📄|🔮|
 [match-document-filename](/rules/match-document-filename)|This rule allows you to enforce that the file name should match the operation name.|![all][]|📦|🚀|
-[naming-convention](/rules/naming-convention)|Require names to follow specified conventions.|![recommended][]|📄 📦|🚀|💡
+[naming-convention](/rules/naming-convention)|Require names to follow specified conventions.|![recommended][]||🚀|💡
 [no-anonymous-operations](/rules/no-anonymous-operations)|Require name for your GraphQL operations. This is useful since most GraphQL client libraries are using the operation name for caching purposes.|![recommended][]|📦|🚀|💡
 [no-deprecated](/rules/no-deprecated)|Enforce that deprecated fields or enum values are not in use by operations.|![recommended][]|📦|🚀|💡
 [no-duplicate-fields](/rules/no-duplicate-fields)|Checks for duplicate fields in selection set, variables in operation definition, or in arguments set of a field.|![recommended][]|📦|🚀|💡
@@ -48,7 +48,7 @@ Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbs
 [overlapping-fields-can-be-merged](/rules/overlapping-fields-can-be-merged)|A selection set is only valid if all fields (including spreading any fragments) either correspond to distinct response names or can be merged without ambiguity.|![recommended][]|📦|🔮|
 [possible-fragment-spread](/rules/possible-fragment-spread)|A fragment spread is only valid if the type condition could ever possibly be true: if there is a non-empty intersection of the possible parent types, and possible types which pass the type condition.|![recommended][]|📦|🔮|
 [possible-type-extension](/rules/possible-type-extension)|A type extension is only valid if the type is defined and has the same kind.|![recommended][]|📄|🔮|💡
-[provided-required-arguments](/rules/provided-required-arguments)|A field or directive is only valid if all required (non-null without a default value) field arguments have been provided.|![recommended][]|📄 📦|🔮|
+[provided-required-arguments](/rules/provided-required-arguments)|A field or directive is only valid if all required (non-null without a default value) field arguments have been provided.|![recommended][]||🔮|
 [relay-arguments](/rules/relay-arguments)|Set of rules to follow Relay specification for Arguments.|![relay][]|📄|🚀|
 [relay-connection-types](/rules/relay-connection-types)|Set of rules to follow Relay specification for Connection types.|![relay][]|📄|🚀|
 [relay-edge-types](/rules/relay-edge-types)|Set of rules to follow Relay specification for Edge types.|![relay][]|📄|🚀|
@@ -67,7 +67,7 @@ Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbs
 [strict-id-in-types](/rules/strict-id-in-types)|Requires output types to have one unique identifier unless they do not have a logical one. Exceptions can be used to ignore output types that do not have unique identifiers.|![recommended][]|📄|🚀|
 [unique-argument-names](/rules/unique-argument-names)|A GraphQL field or directive is only valid if all supplied arguments are uniquely named.|![recommended][]|📦|🔮|
 [unique-directive-names](/rules/unique-directive-names)|A GraphQL document is only valid if all defined directives have unique names.|![recommended][]|📄|🔮|
-[unique-directive-names-per-location](/rules/unique-directive-names-per-location)|A GraphQL document is only valid if all non-repeatable directives at a given location are uniquely named.|![recommended][]|📄 📦|🔮|
+[unique-directive-names-per-location](/rules/unique-directive-names-per-location)|A GraphQL document is only valid if all non-repeatable directives at a given location are uniquely named.|![recommended][]||🔮|
 [unique-enum-value-names](/rules/unique-enum-value-names)|A GraphQL enum type is only valid if all its values are uniquely named.|![recommended][]|📄|🚀|💡
 [unique-field-definition-names](/rules/unique-field-definition-names)|A GraphQL complex type is only valid if all its fields are uniquely named.|![recommended][]|📄|🔮|
 [unique-fragment-name](/rules/unique-fragment-name)|Enforce unique fragment names across your project.|![recommended][]|📦|🚀|

--- a/website/content/rules/known-argument-names.mdx
+++ b/website/content/rules/known-argument-names.mdx
@@ -4,14 +4,13 @@ description: 'A GraphQL field is only valid if all supplied arguments are define
 
 # `known-argument-names`
 
-✅ The `"extends": "plugin:@graphql-eslint/schema-recommended"` and
-`"plugin:@graphql-eslint/operations-recommended"` property in a configuration file enables this
-rule.
+✅ The `"extends": "plugin:@graphql-eslint/schema-and-operations-recommended"` property in a
+configuration file enables this rule.
 
 💡 This rule provides
 [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
 
-- Category: `Schema & Operations`
+- Category: `Schema-and-operations`
 - Rule name: `@graphql-eslint/known-argument-names`
 - Requires GraphQL Schema: `true`
   [ℹ️](/docs/getting-started#extended-linting-rules-with-graphql-schema)

--- a/website/content/rules/known-directives.mdx
+++ b/website/content/rules/known-directives.mdx
@@ -6,11 +6,10 @@ description:
 
 # `known-directives`
 
-✅ The `"extends": "plugin:@graphql-eslint/schema-recommended"` and
-`"plugin:@graphql-eslint/operations-recommended"` property in a configuration file enables this
-rule.
+✅ The `"extends": "plugin:@graphql-eslint/schema-and-operations-recommended"` property in a
+configuration file enables this rule.
 
-- Category: `Schema & Operations`
+- Category: `Schema-and-operations`
 - Rule name: `@graphql-eslint/known-directives`
 - Requires GraphQL Schema: `true`
   [ℹ️](/docs/getting-started#extended-linting-rules-with-graphql-schema)

--- a/website/content/rules/known-type-names.mdx
+++ b/website/content/rules/known-type-names.mdx
@@ -6,14 +6,13 @@ description:
 
 # `known-type-names`
 
-✅ The `"extends": "plugin:@graphql-eslint/schema-recommended"` and
-`"plugin:@graphql-eslint/operations-recommended"` property in a configuration file enables this
-rule.
+✅ The `"extends": "plugin:@graphql-eslint/schema-and-operations-recommended"` property in a
+configuration file enables this rule.
 
 💡 This rule provides
 [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
 
-- Category: `Schema & Operations`
+- Category: `Schema-and-operations`
 - Rule name: `@graphql-eslint/known-type-names`
 - Requires GraphQL Schema: `true`
   [ℹ️](/docs/getting-started#extended-linting-rules-with-graphql-schema)

--- a/website/content/rules/naming-convention.mdx
+++ b/website/content/rules/naming-convention.mdx
@@ -4,14 +4,13 @@ description: 'Require names to follow specified conventions.'
 
 # `naming-convention`
 
-✅ The `"extends": "plugin:@graphql-eslint/schema-recommended"` and
-`"plugin:@graphql-eslint/operations-recommended"` property in a configuration file enables this
-rule.
+✅ The `"extends": "plugin:@graphql-eslint/schema-and-operations-recommended"` property in a
+configuration file enables this rule.
 
 💡 This rule provides
 [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
 
-- Category: `Schema & Operations`
+- Category: `Schema-and-operations`
 - Rule name: `@graphql-eslint/naming-convention`
 - Requires GraphQL Schema: `false`
   [ℹ️](/docs/getting-started#extended-linting-rules-with-graphql-schema)

--- a/website/content/rules/provided-required-arguments.mdx
+++ b/website/content/rules/provided-required-arguments.mdx
@@ -6,11 +6,10 @@ description:
 
 # `provided-required-arguments`
 
-✅ The `"extends": "plugin:@graphql-eslint/schema-recommended"` and
-`"plugin:@graphql-eslint/operations-recommended"` property in a configuration file enables this
-rule.
+✅ The `"extends": "plugin:@graphql-eslint/schema-and-operations-recommended"` property in a
+configuration file enables this rule.
 
-- Category: `Schema & Operations`
+- Category: `Schema-and-operations`
 - Rule name: `@graphql-eslint/provided-required-arguments`
 - Requires GraphQL Schema: `true`
   [ℹ️](/docs/getting-started#extended-linting-rules-with-graphql-schema)

--- a/website/content/rules/unique-directive-names-per-location.mdx
+++ b/website/content/rules/unique-directive-names-per-location.mdx
@@ -6,11 +6,10 @@ description:
 
 # `unique-directive-names-per-location`
 
-✅ The `"extends": "plugin:@graphql-eslint/schema-recommended"` and
-`"plugin:@graphql-eslint/operations-recommended"` property in a configuration file enables this
-rule.
+✅ The `"extends": "plugin:@graphql-eslint/schema-and-operations-recommended"` property in a
+configuration file enables this rule.
 
-- Category: `Schema & Operations`
+- Category: `Schema-and-operations`
 - Rule name: `@graphql-eslint/unique-directive-names-per-location`
 - Requires GraphQL Schema: `true`
   [ℹ️](/docs/getting-started#extended-linting-rules-with-graphql-schema)


### PR DESCRIPTION
## Description

Change type of `RuleDocsInfo.category` to disallow arrays

Fixes #2936

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This is a type change only.


- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

