### PR TITLE
fix(require-selections): validate each union member independently

### DIFF
--- a/.changeset/require-selections-union-members.md
+++ b/.changeset/require-selections-union-members.md
@@ -1,0 +1,8 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+Improve `require-selections` handling of union members so each member is validated independently.
+
+For a field typed as a union, selecting the id field in one member's inline fragment no longer
+satisfies the requirement for a sibling member that omits it.

--- a/packages/plugin/src/rules/require-selections/index.test.ts
+++ b/packages/plugin/src/rules/require-selections/index.test.ts
@@ -316,6 +316,77 @@ ruleTester.run<RuleOptions, true>('require-selections', rule, {
         }
       `,
     },
+    {
+      name: 'should work when every union member selects `id` via inline fragments',
+      code: /* GraphQL */ `
+        {
+          userOrPost {
+            ... on User {
+              id
+              name
+            }
+            ... on Post {
+              id
+              title
+            }
+          }
+        }
+      `,
+      parserOptions: {
+        graphQLConfig: {
+          schema: USER_POST_SCHEMA,
+          documents: '{ foo }',
+        },
+      },
+    },
+    {
+      name: 'should work when every union member selects `id` via named fragment spreads',
+      code: '{ userOrPost { ...UserFields ...PostFields } }',
+      parserOptions: {
+        graphQLConfig: {
+          schema: USER_POST_SCHEMA,
+          documents: /* GraphQL */ `
+            fragment UserFields on User {
+              id
+            }
+            fragment PostFields on Post {
+              id
+            }
+          `,
+        },
+      },
+    },
+    {
+      name: 'should work when `id` is selected in a sibling inline fragment of the same union member',
+      code: /* GraphQL */ `
+        {
+          userOrPost {
+            ... on Post {
+              id
+            }
+            ... on Post {
+              title
+            }
+          }
+        }
+      `,
+      parserOptions: {
+        graphQLConfig: {
+          schema: USER_POST_SCHEMA,
+          documents: '{ foo }',
+        },
+      },
+    },
+    {
+      name: 'should work when `id` for a union member comes from a named fragment spread alongside an inline fragment',
+      code: '{ userOrPost { ...PostId ... on Post { title } } }',
+      parserOptions: {
+        graphQLConfig: {
+          schema: USER_POST_SCHEMA,
+          documents: 'fragment PostId on Post { id }',
+        },
+      },
+    },
   ],
   invalid: [
     {
@@ -396,6 +467,77 @@ ruleTester.run<RuleOptions, true>('require-selections', rule, {
             }
             fragment UserFields on User {
               name
+            }
+          `,
+        },
+      },
+    },
+    {
+      name: 'should report an error when one union member selects `id` via inline fragment but the other does not',
+      errors: [MESSAGE_ID],
+      code: /* GraphQL */ `
+        {
+          userOrPost {
+            ... on User {
+              id
+            }
+            ... on Post {
+              title
+            }
+          }
+        }
+      `,
+      parserOptions: {
+        graphQLConfig: {
+          schema: USER_POST_SCHEMA,
+          documents: '{ foo }',
+        },
+      },
+    },
+    {
+      name: 'should report an error when union members are selected via named fragment spreads and one omits `id`',
+      errors: [MESSAGE_ID],
+      code: '{ userOrPost { ...UserFields ...PostFields } }',
+      parserOptions: {
+        graphQLConfig: {
+          schema: USER_POST_SCHEMA,
+          documents: /* GraphQL */ `
+            fragment UserFields on User {
+              id
+            }
+            fragment PostFields on Post {
+              title
+            }
+          `,
+        },
+      },
+    },
+    {
+      name: 'should report an error when one union member selects `id` inline and another omits it via a named fragment spread',
+      errors: [MESSAGE_ID],
+      code: '{ userOrPost { ... on User { id } ...PostFields } }',
+      parserOptions: {
+        graphQLConfig: {
+          schema: USER_POST_SCHEMA,
+          documents: 'fragment PostFields on Post { title }',
+        },
+      },
+    },
+    {
+      name: 'should report an error when a fragment on the union type selects `id` for one member but not the other',
+      errors: [MESSAGE_ID],
+      code: '{ userOrPost { ...UnionFragment } }',
+      parserOptions: {
+        graphQLConfig: {
+          schema: USER_POST_SCHEMA,
+          documents: /* GraphQL */ `
+            fragment UnionFragment on UserOrPost {
+              ... on User {
+                id
+              }
+              ... on Post {
+                title
+              }
             }
           `,
         },

--- a/packages/plugin/src/rules/require-selections/index.ts
+++ b/packages/plugin/src/rules/require-selections/index.ts
@@ -175,27 +175,66 @@ export const rule: GraphQLESLintRule<RuleOptions, true> = {
       if (rawType instanceof GraphQLObjectType || rawType instanceof GraphQLInterfaceType) {
         checkFields(rawType);
       } else if (rawType instanceof GraphQLUnionType) {
+        const types = rawType.getTypes();
+
+        // Group every selection by the concrete member type it targets, so each
+        // member is validated independently (selecting `id` for one member must
+        // not satisfy a sibling member that omits it) while selections spread
+        // across several inline fragments or spreads of the *same* member are
+        // merged — matching how GraphQL executes them.
+        const selectionSetsByType = new Map<GraphQLObjectType, SelectionSetNode[]>();
+        const addSelectionSet = (t: GraphQLObjectType, selectionSet: SelectionSetNode): void => {
+          const existing = selectionSetsByType.get(t);
+          if (existing) {
+            existing.push(selectionSet);
+          } else {
+            selectionSetsByType.set(t, [selectionSet]);
+          }
+        };
+
         for (const selection of node.selections) {
-          const types = rawType.getTypes();
           if (selection.kind === Kind.INLINE_FRAGMENT) {
             const t = types.find(t => t.name === selection.typeCondition!.name.value);
             if (t) {
-              checkFields(t);
+              addSelectionSet(t, selection.selectionSet);
             }
           } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
             const [foundSpread] = siblings.getFragment(selection.name.value);
-            if (!foundSpread) return;
+            if (!foundSpread) continue;
             const fragmentSpread = foundSpread.document;
-
-            // the fragment is either for the union type itself or one of the types in the union
-            const t =
-              fragmentSpread.typeCondition.name.value === rawType.name
-                ? rawType
-                : types.find(t => t.name === fragmentSpread.typeCondition.name.value)!;
             checkedFragmentSpreads.add(fragmentSpread.name.value);
 
-            checkSelections(fragmentSpread.selectionSet, t, loc, parent, checkedFragmentSpreads);
+            if (fragmentSpread.typeCondition.name.value === rawType.name) {
+              // Fragment declared on the union itself — recurse so its own inline
+              // fragments and spreads get grouped by member type.
+              checkSelections(
+                fragmentSpread.selectionSet,
+                rawType,
+                loc,
+                parent,
+                checkedFragmentSpreads,
+              );
+            } else {
+              const t = types.find(t => t.name === fragmentSpread.typeCondition.name.value);
+              if (t) {
+                addSelectionSet(t, fragmentSpread.selectionSet);
+              }
+            }
           }
+        }
+
+        for (const [t, selectionSets] of selectionSetsByType) {
+          // A single selection set is passed through untouched so ESLint
+          // suggestions (which need real AST positions) keep working; multiple
+          // selection sets for the same member are merged before checking.
+          const selectionSet: OmitRecursively<SelectionSetNode, 'loc'> =
+            selectionSets.length === 1
+              ? selectionSets[0]
+              : {
+                  kind: Kind.SELECTION_SET,
+                  selections: selectionSets.flatMap(s => s.selections),
+                };
+          checkSelections(selectionSet, t, loc, parent, checkedFragmentSpreads);
         }
       }
 

--- a/packages/plugin/src/rules/require-selections/snapshot.md
+++ b/packages/plugin/src/rules/require-selections/snapshot.md
@@ -154,6 +154,78 @@ exports[`require-selections > invalid > should report an error about missing \`u
     Include it in your selection set or add to used fragments \`UserFullFields\` or \`UserFields\`.
 `;
 
+exports[`require-selections > invalid > should report an error when a fragment on the union type selects \`id\` for one member but not the other 1`] = `
+#### ⌨️ Code
+
+      1 | { userOrPost { ...UnionFragment } }
+
+#### ❌ Error
+
+    > 1 | { userOrPost { ...UnionFragment } }
+        |              ^ Field \`userOrPost.id\` must be selected when it's available on a type.
+    Include it in your selection set or add to used fragment \`UnionFragment\`.
+`;
+
+exports[`require-selections > invalid > should report an error when one union member selects \`id\` inline and another omits it via a named fragment spread 1`] = `
+#### ⌨️ Code
+
+      1 | { userOrPost { ... on User { id } ...PostFields } }
+
+#### ❌ Error
+
+    > 1 | { userOrPost { ... on User { id } ...PostFields } }
+        |              ^ Field \`userOrPost.id\` must be selected when it's available on a type.
+    Include it in your selection set or add to used fragment \`PostFields\`.
+`;
+
+exports[`require-selections > invalid > should report an error when one union member selects \`id\` via inline fragment but the other does not 1`] = `
+#### ⌨️ Code
+
+       1 |         {
+       2 |           userOrPost {
+       3 |             ... on User {
+       4 |               id
+       5 |             }
+       6 |             ... on Post {
+       7 |               title
+       8 |             }
+       9 |           }
+      10 |         }
+
+#### ❌ Error
+
+      1 |         {
+    > 2 |           userOrPost {
+        |                      ^ Field \`userOrPost.id\` must be selected when it's available on a type.
+    Include it in your selection set.
+      3 |             ... on User {
+
+#### 💡 Suggestion: Add \`id\` selection
+
+     1 |         {
+     2 |           userOrPost {
+     3 |             ... on User {
+     4 |               id
+     5 |             }
+     6 |             ... on Post {
+     7 |               id title
+     8 |             }
+     9 |           }
+    10 |         }
+`;
+
+exports[`require-selections > invalid > should report an error when union members are selected via named fragment spreads and one omits \`id\` 1`] = `
+#### ⌨️ Code
+
+      1 | { userOrPost { ...UserFields ...PostFields } }
+
+#### ❌ Error
+
+    > 1 | { userOrPost { ...UserFields ...PostFields } }
+        |              ^ Field \`userOrPost.id\` must be selected when it's available on a type.
+    Include it in your selection set or add to used fragments \`UserFields\` or \`PostFields\`.
+`;
+
 exports[`require-selections > invalid > should report an error with union 1`] = `
 #### ⌨️ Code
 


### PR DESCRIPTION
## Description

A field typed as a union that each expose an id field was not reporting a missing id selection when one member's inline fragment selected the id and a sibling member's did not. The requirement check scanned the whole union selection set, so an id in any member satisfied all of them.

My changes now merge selections for the same union member type, then validate each selected type independently. A member that omits the id field is reported even when a sibling member selects it.

Adds valid and invalid tests for named fragment spreads on union members, mixed inline/spread selections, a fragment declared on the union type, and id selected outside a given inline fragment of the same member.

Fixes #2963 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Numerous new unit test cases added covering union type fields and fragments
- [ ] Validate against internal project (TODO, still have some work to do here)

**Test Environment**:

- OS: Linux and macOS
- `@graphql-eslint/...`: 4.4.0
- NodeJS: 22.22.3

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
