### PR TITLE
fix: detect ESLint CLI from the entry point instead of `process.env.NODE`

### DIFF
--- a/.changeset/khaki-poems-cheer.md
+++ b/.changeset/khaki-poems-cheer.md
@@ -1,0 +1,12 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+Decide whether the schema/document cache may skip its freshness check by looking at the process
+entry point instead of `process.env.NODE`.
+
+`NODE` is set by npm and pnpm for every lifecycle script they run, so it meant "launched from a
+package-manager script" rather than "one-shot ESLint CLI run". As a result, long-lived processes
+started with `npm run` / `pnpm run` (lint watchers, language servers, editor tasks) never expired
+the cache and kept linting against a stale schema, while runs started as `npx eslint` or
+`./node_modules/.bin/eslint` still expired entries mid-run.

--- a/packages/plugin/__tests__/cache.spec.ts
+++ b/packages/plugin/__tests__/cache.spec.ts
@@ -1,0 +1,63 @@
+const ORIGINAL_ARGV1 = process.argv[1];
+const ORIGINAL_NODE = process.env.NODE;
+
+const ESLINT_CLI = '/project/node_modules/eslint/bin/eslint.js';
+const LANGUAGE_SERVER = '/project/node_modules/vscode-eslint/server/out/eslintServer.js';
+
+let elapsedSeconds: number;
+
+async function createCache(argv1: string) {
+  process.argv[1] = argv1;
+  vi.resetModules();
+  const { ModuleCache } = await import('../src/cache.js');
+  return new ModuleCache<string, string>();
+}
+
+describe('ModuleCache', () => {
+  beforeEach(() => {
+    elapsedSeconds = 0;
+    vi.spyOn(process, 'hrtime').mockImplementation(((previous?: [number, number]) =>
+      previous ? [elapsedSeconds, 0] : [0, 0]) as typeof process.hrtime);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    process.argv[1] = ORIGINAL_ARGV1;
+    if (ORIGINAL_NODE === undefined) {
+      delete process.env.NODE;
+    } else {
+      process.env.NODE = ORIGINAL_NODE;
+    }
+  });
+
+  it('expires entries after `lifetime` seconds in a long-lived process', async () => {
+    const cache = await createCache(LANGUAGE_SERVER);
+    cache.set('schema', 'old');
+
+    elapsedSeconds = 9;
+    expect(cache.get('schema')).toBe('old');
+
+    elapsedSeconds = 11;
+    expect(cache.get('schema')).toBeUndefined();
+  });
+
+  it('keeps entries for the whole run when invoked as the ESLint CLI', async () => {
+    const cache = await createCache(ESLINT_CLI);
+    cache.set('schema', 'old');
+
+    elapsedSeconds = 3600;
+    expect(cache.get('schema')).toBe('old');
+  });
+
+  // `process.env.NODE` is set by npm and pnpm for every lifecycle script they run, so it cannot
+  // tell a one-shot CLI run from a long-lived process started by `npm run` / `pnpm run`.
+  it('does not treat `process.env.NODE` as an ESLint CLI run', async () => {
+    process.env.NODE = '/usr/local/bin/node';
+    const cache = await createCache(LANGUAGE_SERVER);
+    cache.set('schema', 'old');
+
+    elapsedSeconds = 11;
+    expect(cache.get('schema')).toBeUndefined();
+  });
+});

--- a/packages/plugin/src/cache.ts
+++ b/packages/plugin/src/cache.ts
@@ -4,6 +4,26 @@ import debugFactory from 'debug';
 
 const log = debugFactory('graphql-eslint:ModuleCache');
 
+/**
+ * `true` when this process is a one-shot ESLint CLI run, in which case cached entries never need
+ * to be re-validated - nothing on disk changes while the run is in progress, and expiring entries
+ * mid-run means reloading schemas and documents over and over (see #1246).
+ *
+ * This used to be inferred from `process.env.NODE`, but npm and pnpm both set `NODE` for every
+ * lifecycle script they run, so it really means "launched from a package-manager script" - which
+ * is neither necessary nor sufficient:
+ *
+ * - A long-lived process started with `npm run` / `pnpm run` (a lint watcher, a language server,
+ *   an editor task) got an immortal cache, so schema edits were never picked up - undoing #1222.
+ * - A one-shot run started as `npx eslint` or `./node_modules/.bin/eslint`, or invoked directly
+ *   by a CI image, has `NODE` unset, so entries still expired mid-run - leaving #1246 unfixed for
+ *   those users.
+ *
+ * Checking the entry point instead answers the actual question, and is stable across
+ * `npm`/`pnpm`/`npx`/`.bin` launches (Node resolves `process.argv[1]` to the real script path).
+ */
+const IS_ESLINT_CLI = /[/\\]eslint[/\\]bin[/\\]eslint\.js$/.test(process.argv[1] ?? '');
+
 export class ModuleCache<K, T> {
   map = new Map<K, { lastSeen: [number, number]; result: T }>();
 
@@ -26,10 +46,7 @@ export class ModuleCache<K, T> {
     }
     const { lastSeen, result } = value;
     // check freshness
-    if (
-      process.env.NODE /* don't check for ESLint CLI */ ||
-      process.hrtime(lastSeen)[0] < settings.lifetime
-    ) {
+    if (IS_ESLINT_CLI || process.hrtime(lastSeen)[0] < settings.lifetime) {
       return result;
     }
   }


### PR DESCRIPTION
## Description

`ModuleCache#get` skips its freshness check whenever `process.env.NODE` is set. That was added in #1251 to fix the CI memory regression in #1246, with the intent (per the inline comment) of "don't check for ESLint CLI".

`process.env.NODE` does not mean that. npm and pnpm set it for **every** lifecycle script they run, so it really means "launched from a package-manager script", which is neither necessary nor sufficient — and it misfires in both directions:

- a long-lived process started with `npm run` / `pnpm run` (lint watcher, language server, editor task) gets a permanently immortal cache and never sees schema or document edits, undoing #1222;
- a one-shot run started as `npx eslint`, `./node_modules/.bin/eslint`, or directly by a CI image has `NODE` unset, so entries still expire every 10 s mid-run — the behaviour #1251 was meant to prevent.

This checks the process entry point instead, which answers the actual question:

```ts
const IS_ESLINT_CLI = /[/\\]eslint[/\\]bin[/\\]eslint\.js$/.test(process.argv[1] ?? '');
```

Node resolves `process.argv[1]` to the real script path, so this is stable across every launcher I measured (`npm run`, `pnpm run`, `pnpm exec`, `npx`, `./node_modules/.bin/eslint` all give `…/node_modules/eslint/bin/eslint.js`), and it is `false` for language servers and other embedders.

Fixes #2968

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] **New unit tests** — `packages/plugin/__tests__/cache.spec.ts`, three cases: entries expire after `lifetime` in a long-lived process, entries survive the whole run under the ESLint CLI entry point, and `process.env.NODE` no longer affects the outcome. Two of the three fail against the current implementation; all three pass with this change.
- [x] **End-to-end, with plain ESLint** — the reproduction in #2968 (lint → edit schema → wait 12 s → lint again, in one process). Before: stale forever when `NODE` is set. After: the schema edit is picked up in both cases.
- [x] **Launcher survey** — measured `process.env.NODE` and `process.argv[1]` under `npm run`, `npm exec`, `pnpm run`, `pnpm exec`, `npx`, and `./node_modules/.bin/eslint` (table in #2968).

**Test Environment**:

- OS: macOS (Darwin 25.5.0, arm64)
- `@graphql-eslint/eslint-plugin`: this branch, off `master`
- NodeJS: 26.7.0 (repro also run against ESLint 10.9.1)

> Note: I could only install a filtered workspace locally (`pnpm install --filter @graphql-eslint/eslint-plugin...`), so the `examples`-based specs and anything needing `@theguild/eslint-rule-tester` don't run for me. I compared full `vitest run` output with and without this change and the failure set is identical — the only delta is the new file (+1 file, +3 tests passing). CI should be the real check here.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] A changeset is included (`patch`)

## Further comments

Alternatives I considered:

1. **Drop the short-circuit entirely** and always honour `lifetime`, matching the `eslint-plugin-import` cache this file is based on (which has no such condition). Simplest, but reintroduces #1246.
2. **Make it explicit** — a `settings` option or a namespaced env var. Cleaner in principle, but it's new public API, and it makes the correct behaviour opt-in rather than the default, so most people hitting this would never find it.

I went with the entry-point check because it is strictly better than the status quo in every scenario I could measure without adding API. Happy to switch to (2) — or anything else you'd prefer — if you'd rather have it configurable; just say the word and I'll rework the PR.
